### PR TITLE
Change Export usage 

### DIFF
--- a/lib/DateTime/Format/Strptime.pm
+++ b/lib/DateTime/Format/Strptime.pm
@@ -16,9 +16,12 @@ use Package::DeprecationManager -deprecations => {
     'accessor writers' => '1.58',
 };
 
-use Exporter qw( import );
-
-our @EXPORT_OK = qw( strftime strptime );
+our (@ISA, @EXPORT_OK);
+BEGIN {
+    require Exporter;
+    @ISA = qw(Exporter);
+    @EXPORT_OK = qw(strftime strptime);  # symbols to export on request
+}
 
 use constant PERL_58 => $] < 5.010;
 


### PR DESCRIPTION
We're running some pretty draconian script checks one of which does a perl -cw on all our scripts and barfs if there are any warnings. 
Since the 1.60 release this has been failing due to the use Exporter qw(import) causing a import redefined error.
I've just changed the Exporter usage to use a BEGIN block to get round that. We're patching our version locally but I figured I'd send you the update too. 

Thanks
Simon
